### PR TITLE
remove SLICOT-based code

### DIFF
--- a/src/methods/freqresp.jl
+++ b/src/methods/freqresp.jl
@@ -46,145 +46,91 @@ function _eval(sys::StateSpace, x::Number)
 end
 
 function _eval{M<:Number}(sys::StateSpace, X::AbstractArray{M})
-  # Transform system into Hessenberg form
-  resp = Array(Complex128, size(sys)..., size(X)...)
-
-  sysr        = minreal(sys)
-  A, B, C, D  = sysr.A, sysr.B, sysr.C, sysr.D
-
-  if isempty(A)
-    for idx in CartesianRange(indices(X))
-      resp[:, :, idx] = D + C*((X[idx]*I - A)\B)
-    end
-    return resp
-  end
-
-  F           = hessfact(A)
-  Ah          = F[:H]
-  T           = full(F[:Q])
-  Bh          = T*B
-  Ch          = C/T
-
+  resp = Array{Complex128}(size(sys)..., size(X)...)
   for idx in CartesianRange(indices(X))
-    R           = X[idx]*I - Ah
-    ipiv, info  = luhessfact!(R)
-    if info > 0
-      # s[i] is a pole of the system
-      resp[:, :, idx] = D + Ch*((X[idx]*I - Ah)\Bh)
-    else
-      temp = convert(AbstractMatrix{eltype(R)}, Bh)
-      hesssolve!(R, ipiv, temp)
-      resp[:, :, idx] = D + Ch*temp
-    end
+    resp[:, :, idx] = sys.D + sys.C*((X[idx]*I - sys.A)\sys.B)
   end
   resp
 end
+# function _eval{M<:Number}(sys::StateSpace, X::AbstractArray{M})
+#   # Transform system into Hessenberg form
+#   resp = Array(Complex128, size(sys)..., size(X)...)
+#
+#   sysr        = minreal(sys)
+#   A, B, C, D  = sysr.A, sysr.B, sysr.C, sysr.D
+#
+#   if isempty(A)
+#     for idx in CartesianRange(indices(X))
+#       resp[:, :, idx] = D + C*((X[idx]*I - A)\B)
+#     end
+#     return resp
+#   end
+#
+#   F           = hessfact(A)
+#   Ah          = F[:H]
+#   T           = full(F[:Q])
+#   Bh          = T*B
+#   Ch          = C/T
+#
+#   for idx in CartesianRange(indices(X))
+#     R           = X[idx]*I - Ah
+#     ipiv, info  = luhessfact!(R)
+#     if info > 0
+#       # s[i] is a pole of the system
+#       resp[:, :, idx] = D + Ch*((X[idx]*I - Ah)\Bh)
+#     else
+#       temp = convert(AbstractMatrix{eltype(R)}, Bh)
+#       hesssolve!(R, ipiv, temp)
+#       resp[:, :, idx] = D + Ch*temp
+#     end
+#   end
+#   resp
+# end
 
-"""
-    luhessfact!(H) -> ipiv, info
+# """
+#     luhessfact!(H) -> ipiv, info
+#
+# Compute an LU factorization of an `n×m` upper Hessenberg matrix `H` using partial
+# pivoting with row interchanges.
+#
+# Input/Output Parameters
+#
+#   * `H`: Input/output, `n×m` matrix. At input, the `n×m` upper Hessenberg matrix
+#     to be factored. At output, the factors `L` and `U` from the factorization
+#     `H = P*L*U`; the unit diagonal elements of `L` are not stored, and `L` is lower
+#     bidiagonal.
+#   * `ipiv`: Output, Integer vector of length `m`. The pivot indices; for
+#     `1 ≤ i ≤ m`, row `i` of the matrix was interchanged with row `ipiv(i)`.
+#   * `info`: Output, Integer. `info = 0` implies successful exit. `info = i > 0`
+#     implies `U(i,i)` is exactly zero. The factorization has been completed, but
+#     the factor `U` is exactly singular, and division by zero will occur if it is
+#     used to solve a system of equations.
+# """
+# function luhessfact!{T<:Number}(H::AbstractMatrix{T})
+# end
 
-Compute an LU factorization of an `n×m` upper Hessenberg matrix `H` using partial
-pivoting with row interchanges.
-
-Based on the SLICOT routine `MB02SZ`.
-
-Input/Output Parameters
-
-  * `H`: Input/output, `n×m` matrix. At input, the `n×m` upper Hessenberg matrix
-    to be factored. At output, the factors `L` and `U` from the factorization
-    `H = P*L*U`; the unit diagonal elements of `L` are not stored, and `L` is lower
-    bidiagonal.
-  * `ipiv`: Output, Integer vector of length `m`. The pivot indices; for
-    `1 ≤ i ≤ m`, row `i` of the matrix was interchanged with row `ipiv(i)`.
-  * `info`: Output, Integer. `info = 0` implies successful exit. `info = i > 0`
-    implies `U(i,i)` is exactly zero. The factorization has been completed, but
-    the factor `U` is exactly singular, and division by zero will occur if it is
-    used to solve a system of equations.
-"""
-function luhessfact!{T<:Number}(H::AbstractMatrix{T})
-  n, m = size(H)
-
-  ipiv = zeros(Int,m)
-  info::Int = 0
-
-  for j = 1:m
-    # Find pivot and test for singularity.
-    jp = j
-
-    if j < m
-      if abs(H[j+1,j]) > abs(H[j,j])
-        jp = j + 1
-      end
-    end
-    ipiv[j] = jp
-
-    if H[jp,j] ≉ zero(T)
-      # Apply the interchange to columns J:N.
-      if jp != j
-        for i = j:m
-          temp = H[j,i]
-          H[j,i] = H[jp,i]
-          H[jp,i] = temp
-        end
-      end
-      # Compute element J+1 of J-th column.
-      if j < m
-        H[j+1, j] /= H[j,j]
-      end
-    else
-      if info == 0
-        info = j
-      end
-    end
-
-    if j < m
-      # Update trailing submatrix.
-      H[j+1,j+1:m] -= H[j+1,j] * H[j,j+1:m]
-    end
-  end
-  return ipiv, info
-end
-
-"""
-    hesssolve!(H, ipiv, B)`
-
-Solve the system of linear equations `H * X = B` with an upper Hessenberg `N×N`
-matrix `H` using the `LU` factorization computed by `luhessfact!`.
-
-Based on the SLICOT routine `MB02RZ`.
-
-Input/Output Parameters
-
-  * `H`: Input, `LDH×N` matrix, containing the factors `L` and `U` from the
-    factorization `H = P*L*U` as computed by `luhessfact!`.
-  * `ipiv`: Input, Integer vector of dimension `N`, containing the pivot indices
-    from `luhessfact!`; for `1 ≤ i ≤ N`, row `i` of the matrix was interchanged
-    with row `ipiv(i)`.
-  * `B`: Input/output, `LDB×NRHS` matrix. At input, the right hand side matrix
-    `B`. At output, the solution matrix `X`.
-"""
-function hesssolve!{T<:Number}(H::AbstractMatrix{T},
-  ipiv::AbstractVector{Int}, B::AbstractMatrix{T})
-  LDH, N    = size(H)
-  LDB, NRHS = size(B)
-  # Solve L * X = B, overwriting B with X.
-  #
-  # L is represented as a product of permutations and unit lower
-  # triangular matrices L = P(1) * L(1) * ... * P(n-1) * L(n-1),
-  # where each transformation L(i) is a rank-one modification of
-  # the identity matrix.
-  for j = 1:N-1
-    jp = ipiv[j]
-    if jp != j
-      for i = 1:NRHS
-        temp    = B[jp,i]
-        B[jp,i] = B[j,i]
-        B[j,i]  = temp
-      end
-    end
-    B[j+1,:] -= H[j+1,j]*B[j,:]
-  end
-
-  # Solve U * X = B, overwriting B with X.
-  BLAS.trsm!('L', 'U', 'N', 'N',one(T), H, B)
-end
+# """
+#     hesssolve!(H, ipiv, B)`
+#
+# Solve the system of linear equations `H * X = B` with an upper Hessenberg `N×N`
+# matrix `H` using the `LU` factorization computed by `luhessfact!`.
+#
+# Input/Output Parameters
+#
+#   * `H`: Input, `LDH×N` matrix, containing the factors `L` and `U` from the
+#     factorization `H = P*L*U` as computed by `luhessfact!`.
+#   * `ipiv`: Input, Integer vector of dimension `N`, containing the pivot indices
+#     from `luhessfact!`; for `1 ≤ i ≤ N`, row `i` of the matrix was interchanged
+#     with row `ipiv(i)`.
+#   * `B`: Input/output, `LDB×NRHS` matrix. At input, the right hand side matrix
+#     `B`. At output, the solution matrix `X`.
+# """
+# Solve L * X = B, overwriting B with X.
+#
+# L is represented as a product of permutations and unit lower
+# triangular matrices L = P(1) * L(1) * ... * P(n-1) * L(n-1),
+# where each transformation L(i) is a rank-one modification of
+# the identity matrix.
+# function hesssolve!{T<:Number}(H::AbstractMatrix{T},
+#   ipiv::AbstractVector{Int}, B::AbstractMatrix{T})
+# end


### PR DESCRIPTION
### Changes

To keep LTISystems under a permissive license we should not keep functions derived from SLICOT which is under GPL. Two function are replaced in this pull request. If we would like to add these features (numerically better `freqresp` based on hessenberg structure), they should be clean-room re-implementations, see the discussion [here](https://github.com/JuliaLang/METADATA.jl/pull/11014).

### Reference

JuliaLang/METADATA.jl#11014
